### PR TITLE
Fixes RT#90907 Class::MOP::load_class deprecation warnings

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -46,6 +46,7 @@ Try::Tiny = 0.11
 URI = 1.59
 MooseX::Role::Parameterized = 0
 Data::Printer = 0
+Class::Load = 0.20
 
 
 [Prereqs / RuntimeRecommends]

--- a/lib/Magpie/ConfigReader/XML.pm
+++ b/lib/Magpie/ConfigReader/XML.pm
@@ -5,6 +5,7 @@ use Moose;
 use XML::LibXML;
 use Magpie::Util;
 use Magpie::Plugin::URITemplate;
+use Class::Load;
 
 #use Data::Printer;
 
@@ -243,7 +244,7 @@ sub process_accept_matrix {
 }
 
 sub process_assets {
-    Class::MOP::load_class('Bread::Board');
+    Class::Load::load_class('Bread::Board');
     my $self = shift;
     my $node = shift;
     foreach my $container ($node->findnodes('./container')) {

--- a/lib/Magpie/Event.pm
+++ b/lib/Magpie/Event.pm
@@ -7,6 +7,7 @@ with qw( Magpie::Event::Symbol Magpie::Types );
 use Magpie::Constants;
 use Magpie::SymbolTable;
 use Magpie::Util;
+use Class::Load;
 use Plack::Request;
 use Plack::Response;
 use Try::Tiny;
@@ -195,7 +196,7 @@ sub load_handler {
         my $handler_error = undef;
 
         try {
-            Class::MOP::load_class( $handler );
+            Class::Load::load_class( $handler );
         }
         catch {
             $handler_error = "Fatal error loading handler class '$handler': $_ \n";
@@ -209,7 +210,7 @@ sub load_handler {
         }
 
 		if ( $handler->isa('Plack::Middleware') ) {
-            Class::MOP::load_class( 'Magpie::Transformer::Middleware' );
+            Class::Load::load_class( 'Magpie::Transformer::Middleware' );
 			my $munged_args = {
 				middleware_args => $handler_args,
 				middleware_class => $handler,

--- a/lib/Magpie/Resource/DBIC.pm
+++ b/lib/Magpie/Resource/DBIC.pm
@@ -5,6 +5,7 @@ package Magpie::Resource::DBIC;
 use Moose;
 extends 'Magpie::Resource';
 with 'Magpie::Plugin::DBI';
+use Class::Load;
 use Magpie::Constants;
 use Try::Tiny;
 
@@ -205,7 +206,7 @@ sub POST {
 
     # if we make it here there is no existing record, so make a new one.
     try {
-        Class::MOP::load_class($wrapper_class);
+        Class::Load::load_class($wrapper_class);
         $to_store = $wrapper_class->new(%args);
     }
     catch {

--- a/lib/Magpie/Resource/Kioku.pm
+++ b/lib/Magpie/Resource/Kioku.pm
@@ -7,6 +7,7 @@ extends 'Magpie::Resource';
 use Magpie::Constants;
 use Try::Tiny;
 use KiokuDB;
+use Class::Load;
 
 has data_source => (
     is         => 'ro',
@@ -206,7 +207,7 @@ sub POST {
 
     # if we make it here there is no existing record, so make a new one.
     try {
-        Class::MOP::load_class($wrapper_class);
+        Class::Load::load_class($wrapper_class);
         $to_store = $wrapper_class->new(%args);
     }
     catch {

--- a/lib/Magpie/Types.pm
+++ b/lib/Magpie/Types.pm
@@ -4,6 +4,7 @@ use Moose::Role;
 #use HTTP::Throwable::Factory;
 use Magpie::Error;
 use Moose::Util::TypeConstraints;
+use Class::Load;
 
 my %http_lookup = (
     300 => 'MultipleChoices',
@@ -62,13 +63,13 @@ coerce 'MagpieResourceObject'
         => via {
             my $args = $_;
             my $class = delete $args->{class};
-            Class::MOP::load_class( $class );
+            Class::Load::load_class( $class );
             $class->new( $args );
         },
     => from 'Str'
         => via {
             my $class = shift;
-            Class::MOP::load_class( $class );
+            Class::Load::load_class( $class );
             $class->new;
         },
 ;


### PR DESCRIPTION
This fixes RT#90907: warnings produced by the deprecation of Class::MOP::load_class

See https://rt.cpan.org/Ticket/Display.html?id=90907
