### PR TITLE
Make the breadboard attribute lazy

### DIFF
--- a/lib/Magpie/Component.pm
+++ b/lib/Magpie/Component.pm
@@ -13,6 +13,7 @@ has breadboard => (
     is      => 'rw',
     isa     => 'Magpie::Breadboard',
     default => sub { Magpie::Breadboard->new(); },
+    lazy    => 1,
     handles => [
         qw( add_asset assets resolve_asset internal_assets resolve_internal_asset)
     ],


### PR DESCRIPTION
Something changed in Moose (I think), and now the Bread::Board attr
in Magpie::Component isn't being initialized early enough. Making it lazy shouldn't be an issue
so let's do that.
